### PR TITLE
Added in copy-link functionality.

### DIFF
--- a/web/src/app/components/Lobby.tsx
+++ b/web/src/app/components/Lobby.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 
 import LobbyPlayerList from './LobbyPlayerList';
 import PlayerState from '../interfaces/PlayerState';
@@ -11,6 +11,25 @@ interface LobbyProps {
 };
 
 export default function Lobby({roomID, players, onStart, onLeave}: LobbyProps) {
+
+    const copyRef = useRef<HTMLButtonElement>(null);
+    const [disabledCopyBtn, setDisabledCopyBtn] = useState(false);
+
+    const copyLink = () => {
+        
+        if (copyRef.current) {
+            navigator.clipboard.writeText(window.location.toString())
+            setDisabledCopyBtn(prevState => !prevState)
+
+            setTimeout(() => {
+                if (copyRef.current) {
+                    setDisabledCopyBtn(prevState => !prevState)
+                }
+            }, 2000)
+        }
+        
+    }
+
     return (
         <>
             <div className='relative inline-flex flex-col justify-left rounded-lg bg-gray-100 p-6 mt-8 '>
@@ -23,7 +42,7 @@ export default function Lobby({roomID, players, onStart, onLeave}: LobbyProps) {
 
                     <div className='flex flex-col p-2 mx-4'>
                         
-                        <button className ='btntext bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded'>Copy Link</button>
+                        <button ref={copyRef} disabled={disabledCopyBtn} className={`btntext  ${disabledCopyBtn ? 'bg-gray-400' : 'bg-blue-500 hover:bg-blue-700 text-white'}  font-bold py-2 px-4 rounded`} onClick={copyLink}> {`${disabledCopyBtn ? 'Copied' : `Copy Link`}`}</button>
                         <button className ='btntext bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 mt-2 rounded' onClick={onLeave}>Leave Room</button>
                         <button className ='btntext bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 mt-2 rounded' onClick={onStart}>Start Game</button>
                         {/* <button disabled className ='btntext bg-gray-400 text-white font-bold py-2 px-4 mt-2 rounded'>Waiting for Host...</button> */}


### PR DESCRIPTION
Simple disable button and change of style when the copy link is clicked, and it also copies the link to the users clipboard.
* The button is disabled and changes from `Copy Link` to `Copied!` for 2 seconds.

We can change the styles or the way we give the user feedback once the copy link button has been pressed. I originally wanted to do a toast/pop-up notification but that would involve adding a new package so I resorted not to. We can do it later down the line though if we want to.

![image](https://github.com/user-attachments/assets/f606921f-422a-41a3-af12-ab065ad02fc4)

![image](https://github.com/user-attachments/assets/040a2a66-d910-49dc-9b4c-205c27f9ac72)
