### PR TITLE
Handle mid-game disconnections

### DIFF
--- a/server/src/player.ts
+++ b/server/src/player.ts
@@ -5,6 +5,7 @@ export default class Player {
     place: number;
     username: string;
     host: boolean;
+    connected: boolean;
 
     constructor(username : string) {
         this.username = username;
@@ -12,6 +13,7 @@ export default class Player {
         this.WPM = 0;
         this.place = -1;
         this.host = false;
+        this.connected = true;
     }
 
     reset() {

--- a/server/src/room.ts
+++ b/server/src/room.ts
@@ -1,3 +1,4 @@
+import { isJsxFragment } from 'typescript';
 import Player from './player';
 
 export default class Room {
@@ -30,11 +31,22 @@ export default class Room {
         let playerToRemove : Player | undefined = this.#players.get(playerID);
 
         if(playerToRemove) {
-            this.#players.delete(playerID);
-
+            //if game is in progress, player is marked as disconnected but not removed
+            if(this.gameStarted) {
+                playerToRemove.connected = false;
+            } else {
+                this.#players.delete(playerID);
+            }
+        
+            //choose a new host
             if(playerToRemove.host && this.#players.size > 0) {
-                let newHost : Player = this.#players.values().next().value;
-                newHost.host = true;
+                let newHost: Player | undefined = Array.from(this.#players.values()).find(p => p !== playerToRemove);
+                
+                if(newHost) {
+                    newHost.host = true;
+                }  
+
+                playerToRemove.host = false;
             }
         }
     }
@@ -72,14 +84,24 @@ export default class Room {
         this.numWords = 0;
         this.gameStarted = false;
         this.playersFinished = 0;
-        this.#players.forEach(player => player.reset());
+
+        this.#players.forEach((player, id) => {
+            player.reset();
+            if(!player.connected) {
+                this.#players.delete(id)
+            } 
+        });
+    }
+
+    numConnected() {
+        return Array.from(this.#players.values()).filter(p => p.connected).length;
     }
 
     isEmpty() {
-        return this.#players.size === 0;
+        return this.numConnected() === 0;
     }
 
     gameOver() {
-        return this.#players.size === this.playersFinished;
+        return this.numConnected() <= this.playersFinished;
     }
 }

--- a/server/src/room.ts
+++ b/server/src/room.ts
@@ -1,4 +1,3 @@
-import { isJsxFragment } from 'typescript';
 import Player from './player';
 
 export default class Room {

--- a/web/src/app/components/Game.tsx
+++ b/web/src/app/components/Game.tsx
@@ -137,7 +137,7 @@ export default function Game({roomID}: GameProps) {
             {gameState === GameState.Lobby && (
                 <Lobby roomID={roomID} players={players} isHost={isHost} playerID={currPlayerID.current} onStart={startGame} onLeave={leaveGame}></Lobby>
             )}
-            {gameState === GameState.GameStarted || gameState === GameState.GameOver && (
+            {(gameState === GameState.GameStarted || gameState === GameState.GameOver) && (
                 <GameWindow roomID={roomID} playerID={currPlayerID.current} players={players} gameText={gameText}/>         
             )}
             {gameState === GameState.GameOver && (

--- a/web/src/app/components/Scoreboard.tsx
+++ b/web/src/app/components/Scoreboard.tsx
@@ -12,11 +12,12 @@ interface ScoreboardProps {
 export default function ScoreboardProps({players, playerID, numWords}: ScoreboardProps) {
   return (
     <>
-        {Object.entries(players).map(([id, {username, score, WPM, place}], index) => (
+        {Object.entries(players).map(([id, {username, score, WPM, place, connected}], index) => (
             <div key={id}>
-                <p>{id === playerID ? `${username} (you)` : username }</p>
+                {connected ? <p>{ username }{id === playerID && ' (you)'}</p>
+                : <p className='text-[#545353]'>{ username } (disconnected)</p>}
                 <div className="flex space-x-2">
-                    <Progress color={playerColors[index]} radius="xs" size="xl" value={(score/numWords)*100}  transitionDuration={650} style={{flex: "1"}}/>       
+                    <Progress color={connected ? (playerColors[index]) : ("#6e6e6d")} radius="xs" size="xl" value={(score/numWords)*100}  transitionDuration={650} style={{flex: "1"}}/>       
                     <p className="-mt-1 w-20">{WPM} wpm</p>
                     <p className="-mt-1 w-4" style={{color: placeColors[place]}}>{place > -1 && ordinals[place]}</p>
                 </div>

--- a/web/src/app/interfaces/PlayerState.ts
+++ b/web/src/app/interfaces/PlayerState.ts
@@ -8,4 +8,5 @@ export interface Player {
     WPM: number;
     place: number;
     host: boolean;
+    connected: boolean;
 }


### PR DESCRIPTION
- when a player disconnects mid-game, we want to keep their player data until the game ends
- players are no longer removed when they disconnect mid game. instead, a boolean `connected` is used to track disconnected players
- the scoreboard UI is updated to show when a player disconnects (name and progress bar are greyed out)
- upon game reset, all disconnected players are removed
- game end now functions correctly when players disconnect mid game

![image](https://github.com/user-attachments/assets/50410d52-fae2-4164-93b9-a9974546dbe7)
