### PR TITLE
simplify environment config

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,10 +1,8 @@
 import GameServer from "./server";
+import dotenv from 'dotenv';
 
 function main() {
-
-	if(process.env.NODE_ENV !== 'prod') {
-		require('dotenv').config();
-	}
+	dotenv.config();
 
 	const port = process.env.PORT;
 	const origin = process.env.ORIGIN;


### PR DESCRIPTION
- dotenv does nothing if no `.env` file is present, so we don't need a conditional check for our environment