### PR TITLE
Simplify room filtering

### DIFF
--- a/web/src/app/multiplayer/page.tsx
+++ b/web/src/app/multiplayer/page.tsx
@@ -19,36 +19,18 @@ export default function Multiplayer() {
 
     const [username, setUsername] = useState('');
 
+    const [searchInput, setSearchInput] = useState('');
     const [rooms, setRooms] = useState<Room[]>([]);
-    const [filteredRooms, setFilteredRooms] = useState<Room[]>([]);
 
-    const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        
-        const value = event.target.value;
-
-        if (value.length != 0) {
-            const filtered = rooms.filter((room) => {
-
-                const roomIDMatches = room.roomID.toLowerCase().includes(value.toLowerCase());
-                const hostUsernameMatches = Object.values(room.players).some(
-                    player => player.host && player.username.toLowerCase().includes(value.toLowerCase())
-                );
-
-                return roomIDMatches || hostUsernameMatches
-            });
-
-            setFilteredRooms(filtered);
-        } else {
-            setFilteredRooms(rooms);
-        }
-    };
-
-    useEffect(() => {
-        setFilteredRooms(rooms)
-    }, [rooms])
+    const filteredRooms =  rooms.filter((room) => {
+        const roomIDMatches = room.roomID.toLowerCase().includes(searchInput.toLowerCase());
+        const hostUsernameMatches = Object.values(room.players).some(
+            player => player.host && player.username.toLowerCase().includes(searchInput.toLowerCase())
+        );
+        return roomIDMatches || hostUsernameMatches
+    });
 
     const rows = filteredRooms.map((element) => {
-
         const hostname = Object.values(element.players).find((player) => player.host === true).username
 
         return (
@@ -130,7 +112,8 @@ export default function Multiplayer() {
                                 radius='lg'
                                 inputSize="small"
                                 className="w-28 ml-4"
-                                onChange={handleSearchChange}
+                                value={searchInput}
+                                onChange={(e) => setSearchInput(e.target.value)}
                             />
                         </div>
                     </div>


### PR DESCRIPTION
while working on the multiplayer page socketio events, I noticed the filtering code can be cleaned up a bit. I'm making a separate PR so that the socket event one doesn't get too big



- the search input value should be state since our UI responds to changes in its value 
- filteredRooms is [redundant state](https://react.dev/reference/react/useState#:~:text=If%20the%20value%20you%20need%20can%20be%20computed%20entirely%20from%20the%20current%20props%20or%20other%20state) since it can be computed entirely from the search string + room list. Making it a const variable simplifies our state management and avoids unnecessary re-renders
- removed unnecessary useEffect