### PR TITLE
Clean up socket events

### DIFF
--- a/web/src/app/components/GameWindow.tsx
+++ b/web/src/app/components/GameWindow.tsx
@@ -55,7 +55,7 @@ export default function GameWindow({roomID, playerID, players, gameText} : GameW
 			window.clearInterval(wpmIntervalID.current); //disable WPM updates
 		}
 
-		socket.emit('playerScoreUpdate', roomID, playerID, players[playerID].score);
+		socket.emit('updatePlayerScore', roomID, playerID, players[playerID].score);
     }
 
 	const updateWPM = () => {
@@ -63,7 +63,7 @@ export default function GameWindow({roomID, playerID, players, gameText} : GameW
 		let wordsCompleted : number = correctKeystrokes.current / 5;
 		let WPM : number = Math.round((wordsCompleted / timeElapsed) * 60);
 
-		socket.emit('playerWPMUpdate', roomID, playerID, WPM);
+		socket.emit('updatePlayerWPM', roomID, playerID, WPM);
 	}
 	
     return (

--- a/web/src/app/multiplayer/page.tsx
+++ b/web/src/app/multiplayer/page.tsx
@@ -19,36 +19,18 @@ export default function Multiplayer() {
 
     const [username, setUsername] = useState('');
 
+    const [searchInput, setSearchInput] = useState('');
     const [rooms, setRooms] = useState<Room[]>([]);
-    const [filteredRooms, setFilteredRooms] = useState<Room[]>([]);
 
-    const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        
-        const value = event.target.value;
-
-        if (value.length != 0) {
-            const filtered = rooms.filter((room) => {
-
-                const roomIDMatches = room.roomID.toLowerCase().includes(value.toLowerCase());
-                const hostUsernameMatches = Object.values(room.players).some(
-                    player => player.host && player.username.toLowerCase().includes(value.toLowerCase())
-                );
-
-                return roomIDMatches || hostUsernameMatches
-            });
-
-            setFilteredRooms(filtered);
-        } else {
-            setFilteredRooms(rooms);
-        }
-    };
-
-    useEffect(() => {
-        setFilteredRooms(rooms)
-    }, [rooms])
+    const filteredRooms =  rooms.filter((room) => {
+        const roomIDMatches = room.roomID.toLowerCase().includes(searchInput.toLowerCase());
+        const hostUsernameMatches = Object.values(room.players).some(
+            player => player.host && player.username.toLowerCase().includes(searchInput.toLowerCase())
+        );
+        return roomIDMatches || hostUsernameMatches
+    });
 
     const rows = filteredRooms.map((element) => {
-
         const hostname = Object.values(element.players).find((player) => player.host === true).username
 
         return (
@@ -84,21 +66,18 @@ export default function Multiplayer() {
     }
 
     useEffect(() => {
-
         socket.on('connect', () => {
             socket.emit('getRooms')
         });
 
-        socket.on('getAllRooms', (allRooms: Room[])=> {
-            setRooms([...rooms, ...allRooms])
+        socket.on('updateRooms', (roomList: Room[])=> {
+            setRooms(roomList)
         })
 
         socket.connect();
 
         return (() => {
-            socket.off();
-            socket.off('connect');
-            socket.off('getAllRooms');
+            socket.removeAllListeners();
             socket.disconnect();
         })
 
@@ -130,7 +109,8 @@ export default function Multiplayer() {
                                 radius='lg'
                                 inputSize="small"
                                 className="w-28 ml-4"
-                                onChange={handleSearchChange}
+                                value={searchInput}
+                                onChange={(e) => setSearchInput(e.target.value)}
                             />
                         </div>
                     </div>


### PR DESCRIPTION
Some minor cleanup and refactoring of socket events

- the `joinRoom` now uses a callback to set the response status (success, in progress, full). 
- made the "room full" error take precedence over the "game started" error, since a player would not be able to join a full room regardless of whether a game has started


improved naming consistency:

- renamed the update event names to be consistent with all other events (`playerScoreUpdate` -> `updatePlayerScore`)
- renamed the `getAllRooms` server event to `updateRooms` since it is an event pushed by the server, not a request
- renamed the `allPlayers` event to `updatePlayers` for consistency
- renamed the `startGame`, `resetGame`, and `leaveGame` button event handlers to `playerStart`, etc. to avoid confusion with the identically named socket event handlers