### PR TITLE
Disable join button on started games

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -97,9 +97,10 @@ export default class GameServer {
     
         if(roomToStart) {
             fetchRandomWords().then((text) => {
-                this.io.to(roomID).emit('startGame', text);
                 roomToStart.numWords = text.split(" ").length-1;
                 roomToStart.gameStarted = true;
+                this.io.to(roomID).emit('startGame', text);
+                this.io.emit('updateRooms', this.#getRoomsDTO())
             })
         }
     }
@@ -164,7 +165,8 @@ export default class GameServer {
         let allRooms = Array.from(this.roomIdToRoom, ([key, room]) => ({
             roomID: key,
             players: room.getPlayers(),
-            maxCapacity: room.maxCapacity
+            maxCapacity: room.maxCapacity,
+            gameStarted: room.gameStarted
           }));
 
         return allRooms;

--- a/web/src/app/components/Lobby.tsx
+++ b/web/src/app/components/Lobby.tsx
@@ -36,7 +36,7 @@ export default function Lobby({roomID, players, playerID, onStart, onLeave}: Lob
                     <div className='flex flex-col items-center p-2 mx-20 my-4 mr-44 space-y-5'>
                         <InviteLink/>
                         {players[playerID]?.host ? (
-                            <button className =' w-full bg-[#275E9D] hover:bg-[#1C416B] text-white font-bold rounded py-2' onClick={onStart}>Start Game</button>
+                            <button className ='w-full bg-[#275E9D] hover:bg-[#1C416B] text-white font-bold rounded py-2' onClick={onStart}>Start Game</button>
                         ) : (
                             <p>waiting for host...</p>
                         )}

--- a/web/src/app/components/Lobby.tsx
+++ b/web/src/app/components/Lobby.tsx
@@ -33,12 +33,12 @@ export default function Lobby({roomID, players, playerID, onStart, onLeave}: Lob
                 <div className="flex">
                     <LobbyPlayerList players={players} playerID={playerID}></LobbyPlayerList>
 
-                    <div className='flex flex-col p-2 mx-20 my-4 mr-44 space-y-5'>
+                    <div className='flex flex-col items-center p-2 mx-20 my-4 mr-44 space-y-5'>
                         <InviteLink/>
                         {players[playerID]?.host ? (
-                            <button className ='bg-[#275E9D] hover:bg-[#1C416B] text-white font-bold rounded py-2' onClick={onStart}>Start Game</button>
+                            <button className =' w-full bg-[#275E9D] hover:bg-[#1C416B] text-white font-bold rounded py-2' onClick={onStart}>Start Game</button>
                         ) : (
-                            <p className='pl-8'>waiting for host...</p>
+                            <p>waiting for host...</p>
                         )}
                     </div>
                 </div>

--- a/web/src/app/multiplayer/page.tsx
+++ b/web/src/app/multiplayer/page.tsx
@@ -68,13 +68,6 @@ export default function Multiplayer() {
     const rows = filteredRooms.map((room) => {
         const hostname = Object.values(room.players).find((player) => player.host === true).username
         const full = Object.keys(room.players).length === room.maxCapacity;
-        let btnText = "Join";
-
-        if(full) {
-            btnText = "Full";
-        } else if (room.gameStarted) {
-            btnText = "Started";
-        }
 
         return (
             <Table.Tr key={room.roomID}>
@@ -83,13 +76,12 @@ export default function Multiplayer() {
                 <Table.Td className="w-[25%] pl-5" style={{ textAlign: 'left' }}>{Object.keys(room.players).length} / {room.maxCapacity}</Table.Td>
                 <Table.Td className="w-[25%]"> 
 
-
                 {full || room.gameStarted ? (
                     <button disabled className='border rounded-lg py-1.5 font-semibold min-w-20 bg-[#2e2e2e] border-[#696969] text-[#696969]'>{full ? "Full" : "Started"}</button>
                 ) : (
                     <button  className='border rounded-lg py-1.5 font-semibold min-w-20' onClick={() => joinRoom(room, room.roomID)}>Join</button>
                 )}
-
+                
                 </Table.Td>
             </Table.Tr>
         );


### PR DESCRIPTION
- on the multiplayer page, disable the "Join" button for games that have already started (similar to what we're already doing for full rooms)

![image](https://github.com/user-attachments/assets/6515e13a-2286-458c-8d6d-16895a6c7ec3)


- also add a small fix for a css issue causing the "waiting for host..." text on the lobby page to be misaligned
