### PR TITLE
Fix undefined host error

### DIFF
--- a/web/src/app/multiplayer/page.tsx
+++ b/web/src/app/multiplayer/page.tsx
@@ -66,7 +66,7 @@ export default function Multiplayer() {
     }
 
     const rows = filteredRooms.map((room) => {
-        const hostname = Object.values(room.players).find((player) => player.host === true).username
+        const hostname = Object.values(room.players).find((player) => player.host === true)?.username
         const full = Object.keys(room.players).length === room.maxCapacity;
 
         return (


### PR DESCRIPTION
- since createRoom is now a separate server event from joinRoom, the room will be empty between creation and the first player joining
- because of this, we can't assume that the result of `find((player) => player.host === true).username` will return a defined result. This sometimes caused a client-side exception when visiting the multiplayer page